### PR TITLE
WIP: Import changes from xenial up to version 4.3.3-5ubuntu12.10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,13 @@
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.dsc,*.changes,*.buildinfo'
+
 pipeline {
   agent any
   stages {
     stage('Build source') {
       steps {
         sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
+        stash(name: 'source', includes: stashFileList)
         cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
       }
     }
@@ -17,7 +20,7 @@ pipeline {
               unstash 'source'
               sh '''export architecture="armhf"
 build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+              stash(includes: stashFileList, name: 'build-armhf')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
 
@@ -29,7 +32,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="arm64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+              stash(includes: stashFileList, name: 'build-arm64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           },
@@ -39,7 +42,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="amd64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              stash(includes: stashFileList, name: 'build-amd64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           }
@@ -52,7 +55,7 @@ build-binary.sh'''
         unstash 'build-armhf'
         unstash 'build-arm64'
         unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
+        archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
         sh '''/usr/bin/build-repo.sh'''
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
-String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
-String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.dsc,*.changes,*.buildinfo'
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo'
 
 pipeline {
   agent any

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+isc-dhcp (4.3.3-5ubuntu12.10) xenial; urgency=medium
+
+  * dhclient-script.linux: handle empty case also when waiting for ipv6 link
+    local DAD. (LP: #1718568)
+
+ -- Dan Streetman <dan.streetman@canonical.com>  Fri, 02 Mar 2018 13:16:05 -0500
+
 isc-dhcp (4.3.3-5ubuntu12.9) xenial-security; urgency=medium
 
   * SECURITY UPDATE: DoS via concurrent TCP sessions

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+isc-dhcp (4.3.3-6ubports1+rebuild1) xenial; urgency=medium
+
+  * No-change rebuild after fixing Jenkinsfile.
+
+ -- Ratchanan Srirattanamet <ratchanan@ubports.com>  Thu, 21 Nov 2019 02:23:23 +0700
+
 isc-dhcp (4.3.3-6ubports1) xenial; urgency=medium
 
   * Merge changes from xenial up to version 4.3.3-5ubuntu12.10

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+isc-dhcp (4.3.3-6ubports1) xenial; urgency=medium
+
+  * Merge changes from xenial up to version 4.3.3-5ubuntu12.10
+
+ -- Ratchanan Srirattanamet <ratchanan@ubports.com>  Thu, 14 Nov 2019 23:23:25 +0700
+
 isc-dhcp (4.3.3-6ubports0) xenial; urgency=medium
 
   * debian/apparmor/sbin.dhclient:

--- a/debian/dhclient-script.linux
+++ b/debian/dhclient-script.linux
@@ -167,12 +167,18 @@ ipv6_link_up_and_dad() {
             error "$dev: checking for link-local addresses failed";
             return 1
         }
+        # another note: the output may be empty if the link local tentative addr
+        # isn't up just yet, so we need to make sure there is at least one 'inet6'
+        # match before returning success.  We need to keep checking for both
+        # 'tentative' case and default (no inet6 address) case. (LP: #1718568)
+        # Don't reorder tentative/inet6 - we need to check for tentative first.
         case " $out " in
             *\ dadfailed\ *)
                 error "$dev: ipv6 dad failed."
                 return 1;;
             *\ tentative\ *) :;;
-            *) return 0;;
+            *\ inet6\ *) return 0;;
+            *) :;; 
         esac
         [ $n -lt $attempts ] || {
             error "$dev: time out waiting for permanent link-local address"


### PR DESCRIPTION
This PR brings the change in version 4.3.3-5ubuntu12.10 available in Ubuntu 16.04 to Ubuntu Touch. The change is related to DHCPv6.